### PR TITLE
Allow find to follow symbolic links

### DIFF
--- a/scripts/toggler.sh
+++ b/scripts/toggler.sh
@@ -327,7 +327,7 @@ select_menu() {
     # TODO: refactor
 
     # Get all default layouts
-    local DEFAULT_LAYOUTS=$(find "${__root_dir}/layouts" -type f -exec basename {} \;)
+    local DEFAULT_LAYOUTS=$(find -L "${__root_dir}/layouts" -type f -exec basename {} \;)
 
     local CUSTOM_LAYOUTS
     # If there is a custom layouts directory


### PR DESCRIPTION
This fixes the issue when a symlinked tmux-sidebar-plus can not find default layout selection (empty list).
Works great for me that wants to symlink all my plugins from a dotfiles repo to my home folder.